### PR TITLE
Add attachment functionality

### DIFF
--- a/lib/sendgrid/email.ex
+++ b/lib/sendgrid/email.ex
@@ -29,7 +29,8 @@ defmodule SendGrid.Email do
             template_id: nil,
             substitutions: nil,
             send_at: nil,
-            headers: nil
+            headers: nil,
+            attachments: nil
 
 
   @type t :: %Email{to: nil | [recipient],
@@ -42,11 +43,13 @@ defmodule SendGrid.Email do
                     template_id: nil | String.t,
                     substitutions: nil | substitutions,
                     send_at: nil | integer,
-                    headers: nil | [header] }
+                    headers: nil | [header],
+                    attachments: nil | [attachment]}
 
   @type recipient :: %{ email: String.t, name: String.t | nil }
   @type content :: %{ type: String.t, value: String.t }
   @type header :: { String.t, String.t }
+  @type attachment :: %{content: String.t, type: String.t, filename: String.t, disposition: String.t, content_id: String.t}
 
   @type substitutions :: %{ String.t => String.t }
 
@@ -132,6 +135,24 @@ defmodule SendGrid.Email do
   @spec add_bcc(Email.t, String.t, String.t) :: Email.t
   def add_bcc(%Email{} = email, bcc_address, bcc_name) do
     put_in(email.bcc, add_address_to_list(email.bcc || [], bcc_address, bcc_name))
+  end
+
+  @doc """
+  Adds an attachment to the email. An attachment is a map with the keys:
+    * content
+    * type
+    filename
+    * disposition
+    * content_id
+  """
+
+  @spec add_attachment(Email.t, Attachment.t) :: Email.t
+  def add_attachment(%Email{} = email, attachment) do
+    attachments = case email.attachments do
+      nil -> [attachment]
+      list -> list ++ [attachment]
+    end
+    %{email | attachments: attachments}
   end
 
   @doc """

--- a/lib/sendgrid/mailer.ex
+++ b/lib/sendgrid/mailer.ex
@@ -56,6 +56,7 @@ defmodule SendGrid.Mailer do
       reply_to: email.reply_to,
       send_at: email.send_at,
       template_id: email.template_id,
+      attachments: email.attachments,
       mail_settings: %{ sandbox_mode: %{ enable: sandbox_mode } }
     }
   end

--- a/test/email_test.exs
+++ b/test/email_test.exs
@@ -166,4 +166,21 @@ defmodule SendGrid.Email.Test do
     |> SendGrid.Mailer.send()
   end
 
+  test "add_attachment" do
+    attachment = %{content: "somebase64encodedstring", type: "image/jpeg", filename: "testing.jpg"}
+    email = Email.build()
+      |> Email.add_attachment(attachment)
+    assert email.attachments == [attachment]
+    assert Enum.count(email.attachments) == 1
+  end
+
+  test "add_attachment multiple" do
+    attachment1 = %{content: "somebase64encodedstring", type: "image/jpeg", filename: "testing.jpg"}
+    attachment2 = %{content: "somebase64encodedstring2", type: "image/png", filename: "testing2.jpg"}
+    email = Email.build()
+      |> Email.add_attachment(attachment1)
+      |> Email.add_attachment(attachment2)
+    assert email.attachments == [attachment1, attachment2]
+    assert Enum.count(email.attachments) == 2
+  end
 end


### PR DESCRIPTION
This allows a user of the library to send base64 encoded attachments via SendGrid. It uses the schema described in the [SendGrid Documentation](https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/index.html) . 

