### PR TITLE
Handle no changes for recipient

### DIFF
--- a/lib/sendgrid/marketing_campaigns/contacts/recipients.ex
+++ b/lib/sendgrid/marketing_campaigns/contacts/recipients.ex
@@ -47,4 +47,13 @@ defmodule SendGrid.Contacts.Recipients do
   defp handle_recipient_result(%{body: %{"persisted_recipients" => [recipient_id]}}) do
     {:ok, recipient_id}
   end
+
+  # Handles the result when there were no returned recipients (for example if it's an update which didn't change anything)
+  defp handle_recipient_result(%{body: %{"persisted_recipients" => []}}) do
+    {:error, ["No changes applied for recipient"]}
+  end
+
+  defp handle_recipient_result(_) do
+    {:error, ["Unexpected error"]}
+  end
 end


### PR DESCRIPTION
When we create new recipient it is possible that we actually update an existing one. In such case Sendgrid API doesn't send back the recipient_id inside `persisted_recipients` array. We need to handle this because we can easily get this error: `(MatchError) no match of right hand side value: []`

Also I added search from Sendgrid API