### PR TITLE
Support {:system, env_name} in API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ config :sendgrid,
   api_key: "SENDGRID_API_KEY"
 ```
 
+If you want to use environment variable, use `{:system, "ENV_NAME"}` in your config:
+
+```elixir
+config :sendgrid,
+  api_key: {:system, "SENDGRID_API_KEY"}
+```
+
 If you'd like to enable sandbox mode (emails won't send but will be validated), add the setting to your config:
 
 ```elixir

--- a/lib/sendgrid.ex
+++ b/lib/sendgrid.ex
@@ -25,7 +25,11 @@ defmodule SendGrid do
   end
 
   defp api_key() do
-    api_key = Application.get_env(:sendgrid, :api_key)
+    api_key =
+      case Application.get_env(:sendgrid, :api_key) do
+        {:system, env_name} -> System.get_env(env_name)
+        key -> key
+      end
 
     unless api_key do
       raise RuntimeError, """


### PR DESCRIPTION
Hi @alexgaribay ,

I supported to use `{:system, env_name}` in our config.
Because I previously used System.get_env/1 in my config, but to use it, environment variables are needed at compile time.
