### PR TITLE
Add personalizations to an email

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,41 @@ config :sendgrid,
   phoenix_layout: {MyApp.Web.EmailView, :layout}
 ```
 
+## Personalizations
+
+Personalizations are used to identify who should receive the email as well as specifics about how you would like the email to be handled.
+
+Personalizations allow you to define:
+
+- `to`, `cc`, `bcc` - The recipients of your email.
+- `subject` - The subject of your email.
+- `headers` - Any headers you would like to include in your email.
+- `substitutions` - Any substitutions you would like to be made for your email.
+- `custom_args` - Any custom arguments you would like to include in your email.
+- `send_at` - A specific time that you would like your email to be sent.
+
+## Example
+
+```elixir
+alias SendGrid.{Email, Personalization}
+
+personalization =
+  Personalization.build()
+  |> Personalization.add_to("recipient1@example.com")
+  |> Personalization.add_cc("recipient2@example.com")
+
+Email.build()
+|> Email.add_from("sender@example.com")
+|> Email.add_personalization(personalization)
+|> SendGrid.Mailer.send()
+```
+
+Multiple personalizations may be added to an email allowing you to specify different handling instructions for different copies of your email. For example, you could send the same email to both <john@example.com> and <janeexampexample@example.com>, but set each email to be delivered at different times.
+
+### Limitations
+
+The SendGrid v3 API limits you to 1,000 personalizations per API request. If you need to include more than 1,000 personalizations, please divide these across multiple API requests.
+
 ## Testing
 
 To run the unit tests you will need to create a `config/config.exs` file and provide your own SendGrid API and email address to receive a test email.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Personalizations allow you to define:
 - `custom_args` - Any custom arguments you would like to include in your email.
 - `send_at` - A specific time that you would like your email to be sent.
 
-## Example
+### Example
 
 ```elixir
 alias SendGrid.{Email, Personalization}

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ end
 
 ## Phoenix Views
 
-You can use Phoenix Views to set your HTML and text content of your emails. You just have 
-to provide a view module and template name and you're good to go! Additionally, you can set 
-a layout to render the view in with `SendGrid.Email.put_phoenix_layout/2`. See `SendGrid.Email.put_phoenix_template/3` 
+You can use Phoenix Views to set your HTML and text content of your emails. You just have
+to provide a view module and template name and you're good to go! Additionally, you can set
+a layout to render the view in with `SendGrid.Email.put_phoenix_layout/2`. See `SendGrid.Email.put_phoenix_template/3`
 for complete usage.
 
 ### Examples
@@ -98,4 +98,25 @@ You can set a default layout to render your view in. Set the `:phoenix_layout` c
 ```elixir
 config :sendgrid,
   phoenix_layout: {MyApp.Web.EmailView, :layout}
+```
+
+## Testing
+
+To run the unit tests you will need to create a `config/config.exs` file and provide your own SendGrid API and email address to receive a test email.
+
+```elixir
+use Mix.Config
+
+config :sendgrid,
+  api_key: "<API_KEY>",
+  phoenix_view: SendGrid.Email.Test.EmailView,
+  test_address: "recipient@example.com"
+```
+
+The `config` directory is excluded from the git repository so your API key and email address will not be committed.
+
+Once configured you can run the full test suite including integration tests as follows:
+
+```console
+mix test --include integration
 ```

--- a/lib/sendgrid/mailer.ex
+++ b/lib/sendgrid/mailer.ex
@@ -35,7 +35,6 @@ defmodule SendGrid.Mailer do
   @spec send(SendGrid.Email.t()) :: :ok | {:error, [String.t()]} | {:error, String.t()}
   def send(%Email{} = email) do
     payload = format_payload(email)
-    IO.inspect(payload)
 
     case SendGrid.post(@mail_url, payload, [{"Content-Type", "application/json"}]) do
       {:ok, %{status_code: status_code}} when status_code in [200, 202] -> :ok
@@ -69,6 +68,7 @@ defmodule SendGrid.Mailer do
       |> Enum.map(&to_payload/1)
       |> Enum.concat([email_personalizations])
       |> Enum.reject(fn p -> p == %{} end)
+      |> Enum.reverse()
 
     headers =
       headers

--- a/lib/sendgrid/personalization.ex
+++ b/lib/sendgrid/personalization.ex
@@ -1,0 +1,238 @@
+defmodule SendGrid.Personalization do
+  @moduledoc """
+  Personalizations are used by SendGrid v3 API to identify who should receive
+  the email as well as specifics about how you would like the email to be handled.
+
+  Personalizations allow you to define:
+
+    - `to`, `cc`, `bcc` - The recipients of your email.
+    - `subject` - The subject of your email.
+    - `headers` - Any headers you would like to include in your email.
+    - `substitutions` - Any substitutions you would like to be made for your email.
+    - `custom_args` - Any custom arguments you would like to include in your email.
+    - `send_at` - A specific time that you would like your email to be sent.
+
+  ## Example
+
+      alias SendGrid.{Email, Personalization}
+
+      personalization =
+        Personalization.build()
+        |> Personalization.add_to("recipient1@example.com")
+        |> Personalization.add_to("recipient2@example.com")
+
+      Email.build()
+      |> Email.add_from("sender@example.com")
+      |> Email.add_personalization(personalization)
+      |> SendGrid.Mailer.send()
+
+  """
+
+  alias SendGrid.Personalization
+
+  defstruct to: nil,
+            cc: nil,
+            bcc: nil,
+            subject: nil,
+            substitutions: nil,
+            custom_args: nil,
+            send_at: nil,
+            headers: nil
+
+  @type t :: %Personalization{
+          to: nil | [SendGrid.Email.recipient()],
+          cc: nil | [SendGrid.Email.recipient()],
+          bcc: nil | [SendGrid.Email.recipient()],
+          subject: nil | String.t(),
+          substitutions: nil | SendGrid.Email.substitutions(),
+          custom_args: nil | SendGrid.Email.custom_args(),
+          send_at: nil | integer,
+          headers: nil | [SendGrid.Email.header()]
+        }
+
+  @doc """
+  Builds an an empty personalization to compose on.
+
+  ## Examples
+
+      alias SendGrid.Personalization
+
+      Personalization.build()
+      |> Personalization.add_to("test@email.com")
+
+  """
+  @spec build :: t
+  def build do
+    %Personalization{}
+  end
+
+  @doc """
+  Sets the `to` field for the personalization.
+
+  A to-name can be passed as the third parameter.
+
+  ## Examples
+
+      Personalization.add_to(%Personalization{}, "test@email.com")
+      Personalization.add_to(%Personalization{}, "test@email.com", "John Doe")
+
+  """
+  @spec add_to(t, String.t()) :: t
+  def add_to(%Personalization{to: to} = p, to_address) do
+    addresses = add_address_to_list(to, to_address)
+    %Personalization{p | to: addresses}
+  end
+
+  @spec add_to(t, String.t(), String.t()) :: t
+  def add_to(%Personalization{to: to} = p, to_address, to_name) do
+    addresses = add_address_to_list(to, to_address, to_name)
+    %Personalization{p | to: addresses}
+  end
+
+  @doc """
+  Add recipients to the `CC` address field.
+
+  The cc-name can be specified as the third parameter.
+
+  ## Examples
+
+      Personalization.add_cc(%Personalization{}, "test@email.com")
+      Personalization.add_cc(%Personalization{}, "test@email.com", "John Doe")
+
+  """
+  @spec add_cc(t, String.t()) :: t
+  def add_cc(%Personalization{cc: cc} = p, cc_address) do
+    addresses = add_address_to_list(cc, cc_address)
+    %Personalization{p | cc: addresses}
+  end
+
+  @spec add_cc(Personalization.t(), String.t(), String.t()) :: t
+  def add_cc(%Personalization{cc: cc} = p, cc_address, cc_name) do
+    addresses = add_address_to_list(cc, cc_address, cc_name)
+    %Personalization{p | cc: addresses}
+  end
+
+  @doc """
+  Add recipients to the `BCC` address field.
+
+  The bcc-name can be specified as the third parameter.
+
+  ## Examples
+
+      Personalization.add_bcc(%Personalization{}, "test@email.com")
+      Personalization.add_bcc(%Personalization{}, "test@email.com", "John Doe")
+
+  """
+  @spec add_bcc(t, String.t()) :: t
+  def add_bcc(%Personalization{bcc: bcc} = p, bcc_address) do
+    addresses = add_address_to_list(bcc, bcc_address)
+    %Personalization{p | bcc: addresses}
+  end
+
+  @spec add_bcc(t, String.t(), String.t()) :: t
+  def add_bcc(%Personalization{bcc: bcc} = p, bcc_address, bcc_name) do
+    addresses = add_address_to_list(bcc, bcc_address, bcc_name)
+    %Personalization{p | bcc: addresses}
+  end
+
+  @doc """
+  Sets the `subject` field for the personalization.
+
+  ## Examples
+
+      Personalization.put_subject(%Personalization{}, "Hello from Elixir")
+
+  """
+  @spec put_subject(t, String.t()) :: t
+  def put_subject(%Personalization{} = p, subject) do
+    %Personalization{p | subject: subject}
+  end
+
+  @doc """
+  Sets a custom header.
+
+  ## Examples
+
+      Personalization.add_header(%Personalization{}, "HEADER_KEY", "HEADER_VALUE")
+
+  """
+  @spec add_header(t, String.t(), String.t()) :: t
+  def add_header(%Personalization{headers: nil} = p, header_key, header_value) do
+    %Personalization{p | headers: [{header_key, header_value}]}
+  end
+
+  def add_header(%Personalization{headers: [_ | _] = headers} = p, header_key, header_value) do
+    headers = headers ++ [{header_key, header_value}]
+    %Personalization{p | headers: headers}
+  end
+
+  @doc """
+  Adds a substitution value to be used with a template.
+
+  If a substitution for a given name is already set, it will be replaced when adding
+  a substitution with the same name.
+
+  ## Examples
+
+      Personalization.add_substitution(%Personalization{}, "-sentIn-", "Elixir")
+
+  """
+  @spec add_substitution(t, String.t(), String.t()) :: t
+  def add_substitution(
+        %Personalization{substitutions: substitutions} = p,
+        sub_name,
+        sub_value
+      ) do
+    substitutions = Map.put(substitutions || %{}, sub_name, sub_value)
+    %Personalization{p | substitutions: substitutions}
+  end
+
+  @doc """
+  Adds a custom_arg value to the personalization.
+
+  If an argument for a given name is already set, it will be replaced when adding
+  a argument with the same name.
+
+  ## Examples
+
+      Personalization.add_custom_arg(%Personalization{}, "-sentIn-", "Elixir")
+
+  """
+  @spec add_custom_arg(t, String.t(), String.t()) :: t
+  def add_custom_arg(%Personalization{custom_args: custom_args} = p, arg_name, arg_value) do
+    custom_args = Map.put(custom_args || %{}, arg_name, arg_value)
+    %Personalization{p | custom_args: custom_args}
+  end
+
+  @doc """
+  Sets a future date of when to send the email.
+
+  ## Examples
+
+      Personalization.put_send_at(%Personalization{}, 1409348513)
+
+  """
+  @spec put_send_at(t, integer) :: t
+  def put_send_at(%Personalization{} = p, send_at) do
+    %Personalization{p | send_at: send_at}
+  end
+
+  defp address(email), do: %{email: email}
+  defp address(email, name), do: %{email: email, name: name}
+
+  defp add_address_to_list(nil, email) do
+    [address(email)]
+  end
+
+  defp add_address_to_list(list, email) when is_list(list) do
+    list ++ [address(email)]
+  end
+
+  defp add_address_to_list(nil, email, name) do
+    [address(email, name)]
+  end
+
+  defp add_address_to_list(list, email, name) when is_list(list) do
+    list ++ [address(email, name)]
+  end
+end

--- a/test/mailer_test.exs
+++ b/test/mailer_test.exs
@@ -1,6 +1,6 @@
 defmodule SendGrid.MailerTest do
   use ExUnit.Case
-  alias SendGrid.{Email, Mailer}
+  alias SendGrid.{Email, Mailer, Personalization}
 
   @tag integration: true
   test "send" do
@@ -17,6 +17,50 @@ defmodule SendGrid.MailerTest do
     assert :ok == result
   end
 
+  @tag integration: true
+  test "send personalizations" do
+    personalization =
+      Personalization.build()
+      |> Personalization.add_to(Application.get_env(:sendgrid, :test_address))
+      |> Personalization.put_subject("Test")
+      |> Personalization.add_header("TEST", "FOO")
+
+    result =
+      Email.build()
+      |> Email.put_from(Application.get_env(:sendgrid, :test_address))
+      |> Email.put_text("123")
+      |> Email.put_html("<p>123</p>")
+      |> Email.add_personalization(personalization)
+      |> SendGrid.Mailer.send()
+
+    assert :ok == result
+  end
+
+  @tag integration: true
+  test "send multiple personalizations" do
+    personalization1 =
+      Personalization.build()
+      |> Personalization.add_to(Application.get_env(:sendgrid, :test_address))
+      |> Personalization.put_subject("Test1")
+      |> Personalization.add_header("TEST1", "FOO")
+
+    personalization2 =
+      Personalization.build()
+      |> Personalization.add_to(Application.get_env(:sendgrid, :test_address))
+      |> Personalization.put_subject("Test2")
+
+    result =
+      Email.build()
+      |> Email.put_from(Application.get_env(:sendgrid, :test_address))
+      |> Email.put_text("123")
+      |> Email.put_html("<p>123</p>")
+      |> Email.add_personalization(personalization1)
+      |> Email.add_personalization(personalization2)
+      |> SendGrid.Mailer.send()
+
+    assert :ok == result
+  end
+
   describe "format_payload" do
     test "removes nil/emply personalizations" do
       assert Mailer.format_payload(Email.build()) ==
@@ -26,7 +70,7 @@ defmodule SendGrid.MailerTest do
                  from: nil,
                  headers: %{},
                  mail_settings: %{sandbox_mode: %{enable: false}},
-                 personalizations: [%{}],
+                 personalizations: [],
                  reply_to: nil,
                  send_at: nil,
                  subject: nil,

--- a/test/mailer_test.exs
+++ b/test/mailer_test.exs
@@ -19,7 +19,19 @@ defmodule SendGrid.MailerTest do
 
   describe "format_payload" do
     test "removes nil/emply personalizations" do
-      assert Mailer.format_payload(Email.build()) == [%{}]
+      assert Mailer.format_payload(Email.build()) ==
+               %{
+                 attachments: nil,
+                 content: nil,
+                 from: nil,
+                 headers: %{},
+                 mail_settings: %{sandbox_mode: %{enable: false}},
+                 personalizations: [%{}],
+                 reply_to: nil,
+                 send_at: nil,
+                 subject: nil,
+                 template_id: nil
+               }
     end
 
     test "includes custom header" do

--- a/test/personalization_test.exs
+++ b/test/personalization_test.exs
@@ -1,0 +1,138 @@
+defmodule SendGrid.Personalization.Test do
+  use ExUnit.Case, async: true
+  alias SendGrid.Personalization
+
+  @email "test@email.com"
+  @name "John Doe"
+
+  test "build/0" do
+    assert Personalization.build() == %Personalization{}
+  end
+
+  test "add_to/2" do
+    personalization = Personalization.add_to(Personalization.build(), @email)
+    assert personalization.to == [%{email: @email}]
+  end
+
+  test "add_to/3" do
+    personalization = Personalization.add_to(Personalization.build(), @email, @name)
+    assert personalization.to == [%{email: @email, name: @name}]
+  end
+
+  test "add_to with multiple addresses" do
+    personalization =
+      Personalization.build()
+      |> Personalization.add_to(@email)
+      |> Personalization.add_to(@email, @name)
+
+    assert personalization.to == [%{email: @email}, %{email: @email, name: @name}]
+  end
+
+  test "add_cc/2" do
+    personalization = Personalization.add_cc(Personalization.build(), @email)
+    assert personalization.cc == [%{email: @email}]
+  end
+
+  test "add_cc/3" do
+    personalization = Personalization.add_cc(Personalization.build(), @email, @name)
+    assert personalization.cc == [%{email: @email, name: @name}]
+  end
+
+  test "add_cc with multiple addresses" do
+    personalization =
+      Personalization.build()
+      |> Personalization.add_cc(@email)
+      |> Personalization.add_cc(@email, @name)
+
+    assert personalization.cc == [%{email: @email}, %{email: @email, name: @name}]
+  end
+
+  test "add_bcc/2" do
+    personalization = Personalization.add_bcc(Personalization.build(), @email)
+    assert personalization.bcc == [%{email: @email}]
+  end
+
+  test "add_bcc/3" do
+    personalization = Personalization.add_bcc(Personalization.build(), @email, @name)
+    assert personalization.bcc == [%{email: @email, name: @name}]
+  end
+
+  test "add_bcc with multiple addresses" do
+    personalization =
+      Personalization.build()
+      |> Personalization.add_bcc(@email)
+      |> Personalization.add_bcc(@email, @name)
+
+    assert personalization.bcc == [%{email: @email}, %{email: @email, name: @name}]
+  end
+
+  test "put_subject/2" do
+    subject = "Test Subject"
+    personalization = Personalization.put_subject(Personalization.build(), subject)
+    assert personalization.subject == subject
+  end
+
+  test "add_header/3" do
+    header_key = "SOME_KEY"
+    header_value = "SOME_VALUE"
+
+    personalization =
+      Personalization.add_header(Personalization.build(), header_key, header_value)
+
+    assert personalization.headers == [{header_key, header_value}]
+  end
+
+  test "add_substitution/3" do
+    personalization =
+      Personalization.add_substitution(Personalization.build(), "-someValue-", "Cool")
+
+    assert personalization.substitutions == %{"-someValue-" => "Cool"}
+  end
+
+  test "add_subtitution/3 x2" do
+    personalization =
+      Personalization.build()
+      |> Personalization.add_substitution("-someValue-", "Cool")
+      |> Personalization.add_substitution("-newValue-", "Panda")
+
+    assert personalization.substitutions == %{"-someValue-" => "Cool", "-newValue-" => "Panda"}
+  end
+
+  test "add_custom_arg/3" do
+    personalization =
+      Personalization.add_custom_arg(Personalization.build(), "unique_user_id", "abc123")
+
+    assert personalization.custom_args == %{"unique_user_id" => "abc123"}
+  end
+
+  test "add_custom_arg/3 x2" do
+    personalization =
+      Personalization.build()
+      |> Personalization.add_custom_arg("unique_user_id", "abc123")
+      |> Personalization.add_custom_arg("template_name", "welcome-user")
+
+    assert personalization.custom_args == %{
+             "unique_user_id" => "abc123",
+             "template_name" => "welcome-user"
+           }
+  end
+
+  test "add_custom_arg/3 does not create duplicate keys" do
+    personalization =
+      Personalization.build()
+      |> Personalization.add_custom_arg("unique_user_id", "abc123")
+      |> Personalization.add_custom_arg("template_name", "welcome-user")
+      |> Personalization.add_custom_arg("template_name", "new_template")
+
+    assert personalization.custom_args == %{
+             "unique_user_id" => "abc123",
+             "template_name" => "new_template"
+           }
+  end
+
+  test "put_send_at/2" do
+    time = 123_456_789
+    personalization = Personalization.put_send_at(Personalization.build(), time)
+    assert personalization.send_at == time
+  end
+end


### PR DESCRIPTION
[SendGrid personalizations](https://sendgrid.com/docs/for-developers/sending-email/personalizations/) are used to identify who should receive the email as well as specifics about how you would like the email to be handled.

Personalizations allow you to define:

- `to`, `cc`, `bcc` - The recipients of your email.
- `subject` - The subject of your email.
- `headers` - Any headers you would like to include in your email.
- `substitutions` - Any substitutions you would like to be made for your email.
- `custom_args` - Any custom arguments you would like to include in your email.
- `send_at` - A specific time that you would like your email to be sent.

Multiple personalizations may be added to an email allowing you to specify different handling instructions for different copies of your email. For example, you could send the same email to both `john@example.com` and `janeexampexample@example.com`, but set each email to be delivered at different times.

## Example

```elixir
alias SendGrid.{Email, Personalization}

personalization =
  Personalization.build()
  |> Personalization.add_to("recipient1@example.com")
  |> Personalization.add_cc("recipient2@example.com")

Email.build()
|> Email.add_from("sender@example.com")
|> Email.add_personalization(personalization)
|> SendGrid.Mailer.send()
```