### PR TITLE
Email.put_phoenix_template spec should allow lists of any length

### DIFF
--- a/lib/sendgrid/email.ex
+++ b/lib/sendgrid/email.ex
@@ -550,7 +550,7 @@ defmodule SendGrid.Email do
 
   """
   def put_phoenix_template(email, template_name, assigns \\ [])
-  @spec put_phoenix_template(t, atom, []) :: t
+  @spec put_phoenix_template(t, atom, list()) :: t
   def put_phoenix_template(%Email{} = email, template_name, assigns) when is_atom(template_name) do
     with true <- ensure_phoenix_loaded(),
          view_mod <- phoenix_view_module(email),
@@ -562,7 +562,7 @@ defmodule SendGrid.Email do
     end
   end
 
-  @spec put_phoenix_template(t, String.t(), []) :: t
+  @spec put_phoenix_template(t, String.t(), list()) :: t
   def put_phoenix_template(%Email{} = email, template_name, assigns) do
     with true <- ensure_phoenix_loaded(),
          view_mod <- phoenix_view_module(email),


### PR DESCRIPTION
Previously, dialyzer reports usage of Email.put_phoenix_template with
non-empty assigns as an invalid use of the function. This simple change
informs dialyzer that invocations should allow empty or non-empty
keyword lists.

Failing Example:

```elixir
def tester() do
  # Dialyzer does not complain about this invocation
  test([])

  # Dialyzer complains here that the given argument
  # breaks the contract
  test(foo: "bar")
end

# Using a bare list `[]` here denotes only empty lists are valid arguments
@spec test([]) :: any()
def test(assigns) do
  assigns
end
```

Working Example:

```elixir
def tester() do
  # Dialyzer does not complain about either invocation
  test([])
  test(foo: "bar")
end

@spec test(list()) :: any()
def test(assigns) do
  assigns
end
```