### PR TITLE
Add configurable adapter for tesla

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ defp application do
 end
 ```
 
+Configure adapter options.
+
+```elixir
+config :sendgrid,
+  adapter: {Tesla.Adapter.Httpc, [timeout: 30000, proxy: "http://proxy:9999"]}
+```
+
 ## Phoenix Views
 
 You can use Phoenix Views to set your HTML and text content of your emails. You just have

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,4 +4,5 @@ config :sendgrid,
   api_key: {:system, "SENDGRID_API_KEY"},
   sandbox_enable: true,
   phoenix_view: SendGrid.EmailView,
-  test_address: System.get_env("SENDGRID_TEST_EMAIL")
+  test_address: System.get_env("SENDGRID_TEST_EMAIL"),
+  adapter: {Tesla.Adapter.Httpc, []}

--- a/lib/sendgrid.ex
+++ b/lib/sendgrid.ex
@@ -135,6 +135,8 @@ defmodule SendGrid do
     end
   end
 
+  defp adapter, do: Application.get_env(:sendgrid, :adapter)
+
   defp build_client(api_key) do
     middleware = [
       {Tesla.Middleware.BaseUrl, "https://api.sendgrid.com"},
@@ -142,7 +144,7 @@ defmodule SendGrid do
       {Tesla.Middleware.Headers, [{"Authorization", "Bearer #{api_key}"}]}
     ]
 
-    Tesla.client(middleware)
+    Tesla.client(middleware, adapter())
   end
 
   defp query_opts(opts) do


### PR DESCRIPTION
In some cases you might need to change the tesla adapter options, for example, you might need to have a proxy configured to use the SendGrid web API.

```elixir
config :sendgrid,
  adapter: {Tesla.Adapter.Hackney, [proxy: "http://192.168.1.1:8888"]}
```

 Here we add a configurable adapter for Tesla injected through the `Tesla.client/2`. If the adapter isn't configured the default is used.