### PR TITLE
feat: adds PUT request

### DIFF
--- a/lib/sendgrid.ex
+++ b/lib/sendgrid.ex
@@ -73,6 +73,24 @@ defmodule SendGrid do
   end
 
   @doc """
+  performs a PUT request.
+
+  ## Options
+
+  * `:api_key` - API key to use with the request.
+  * `:query` - Keyword list of query params to use with the request.
+  """
+  @spec put(path :: String.t(), body :: map(), options :: options()) ::
+          {:ok, Response.t()} | {:error, any()}
+  def put(path, body, opts \\ []) when is_map(body) and is_list(opts) do
+    opts
+    |> api_key()
+    |> build_client()
+    |> Tesla.put(path, body, query_opts(opts))
+    |> parse_response()
+  end
+
+  @doc """
   Performs a PATCH request.
 
   ## Options


### PR DESCRIPTION
# Description 📖  
Adding a new contact into the **marketing contact list** requires that the HTTP method is **PUT**. These PR ads this type of request to the main SendGrid module.

![](https://media.giphy.com/media/3v8p5BksFOBe8/giphy.gif)