### PR TITLE
extend spec for add_dynamic_template_data

### DIFF
--- a/lib/sendgrid/email.ex
+++ b/lib/sendgrid/email.ex
@@ -406,10 +406,13 @@ defmodule SendGrid.Email do
 
   ## Examples
 
+      Email.add_dynamic_template_data(%Email{}, "is_default", true)
       Email.add_dynamic_template_data(%Email{}, "-sentIn-", "Elixir")
+      Email.add_dynamic_template_data(%Email{}, "statuses", ["processing", "send", "pending"])
+      Email.add_dynamic_template_data(%Email{}, "mappings", %{"send_grid" => "SendGrid"})
 
   """
-  @spec add_dynamic_template_data(t, String.t(), String.t()) :: t
+  @spec add_dynamic_template_data(t, String.t(), any()) :: t
   def add_dynamic_template_data(
         %Email{dynamic_template_data: dynamic_template_data} = email,
         arg_name,


### PR DESCRIPTION
Can we extend `add_dynamic_template_data/3` function spec since in sendgrid templates is possible to do any of these:
```
{{#if is_default}}
{{#each statuses as |status|}}
```

Thanks,